### PR TITLE
升级 SK 到  V1.4，升级基础库。为避免和 Kernel 库的命名冲突，重命名 Senparc.AI.Register.UseSen…

### DIFF
--- a/Samples/Senparc.AI.Samples.Consoles/Senparc.AI.Samples.Consoles.csproj
+++ b/Samples/Senparc.AI.Samples.Consoles/Senparc.AI.Samples.Consoles.csproj
@@ -20,7 +20,7 @@
 	  <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-	  <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.0.1" />
+	  <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.4.0" />
 	  <PackageReference Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.0.1-preview" />
 	  <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.0.1-alpha" />
 	  <!--<PackageReference Include="Microsoft.SemanticKernel.Planning.SequentialPlanner" Version="0.24.230912.2-preview" />-->

--- a/src/Senparc.AI.Kernel.Tests/Senparc.AI.Kernel.Tests.csproj
+++ b/src/Senparc.AI.Kernel.Tests/Senparc.AI.Kernel.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Senparc.AI.Kernel/Register.cs
+++ b/src/Senparc.AI.Kernel/Register.cs
@@ -65,8 +65,7 @@ namespace Senparc.AI.Kernel
         /// <returns></returns>
         public static IRegisterService UseSenparcAI(this IRegisterService registerService)
         {
-            return Senparc.AI.Register.UseSenparcAI(registerService);
+            return Senparc.AI.Register.UseSenparcAICore(registerService);
         }
-
     }
 }

--- a/src/Senparc.AI.Kernel/Senparc.AI.Kernel.csproj
+++ b/src/Senparc.AI.Kernel/Senparc.AI.Kernel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>0.14.0</Version>
+		<Version>0.14.1</Version>
 		<Nullable>enable</Nullable>
 		<LangVersion>10.0</LangVersion>
 		<AssemblyName>Senparc.AI.Kernel</AssemblyName>
@@ -57,12 +57,12 @@
 		<None Include="KernelConfigExtensions\KernelConfigExtensions.Function.cs" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.0.1" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.4.0" />
 		<PackageReference Include="Microsoft.SemanticKernel.Connectors.HuggingFace" Version="1.0.1-preview" />
 		<!--<PackageReference Include="Microsoft.SemanticKernel.Functions.Semantic" Version="1.0.0-beta2" />-->
 		<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.0.1-alpha" />
 
-		<PackageReference Include="Senparc.CO2NET" Version="2.3.1" />
+		<PackageReference Include="Senparc.CO2NET" Version="2.4.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Senparc.AI\Senparc.AI.csproj" />

--- a/src/Senparc.AI.Tests/Senparc.AI.Tests.csproj
+++ b/src/Senparc.AI.Tests/Senparc.AI.Tests.csproj
@@ -30,14 +30,14 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Senparc.CO2NET.AspNet" Version="1.3.1" />
-    <PackageReference Include="Senparc.CO2NET.Cache.Redis" Version="4.2.1" />
+    <PackageReference Include="Senparc.CO2NET.AspNet" Version="1.3.2" />
+    <PackageReference Include="Senparc.CO2NET.Cache.Redis" Version="4.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Senparc.AI/Register.cs
+++ b/src/Senparc.AI/Register.cs
@@ -20,7 +20,7 @@ namespace Senparc.AI
         /// <param name="registerService"></param>
         /// <param name="senparcAiSetting"></param>
         /// <returns></returns>
-        public static IRegisterService UseSenparcAI(this IRegisterService registerService)
+        public static IRegisterService UseSenparcAICore(this IRegisterService registerService)
         {
            
             return registerService;

--- a/src/Senparc.AI/Senparc.AI.csproj
+++ b/src/Senparc.AI/Senparc.AI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>0.14.0</Version>
+		<Version>0.14.1</Version>
 		<Nullable>enable</Nullable>
 		<LangVersion>10.0</LangVersion>
 		<AssemblyName>Senparc.AI</AssemblyName>
@@ -61,6 +61,6 @@
 
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 
-		<PackageReference Include="Senparc.CO2NET" Version="2.3.1" />
+		<PackageReference Include="Senparc.CO2NET" Version="2.4.0.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
…parAI 为 UseSenparcCore