### PR TITLE
添加第三方代理OpenAI API支持

### DIFF
--- a/src/Senparc.AI.Kernel/Handlers/SemanticAiHandler.cs
+++ b/src/Senparc.AI.Kernel/Handlers/SemanticAiHandler.cs
@@ -10,6 +10,7 @@ using Senparc.AI.Interfaces;
 using Senparc.AI.Kernel.Entities;
 using Senparc.AI.Kernel.Handlers;
 using Senparc.AI.Kernel.Helpers;
+using Senparc.AI.Kernel.HttpMessageHandlers;
 
 namespace Senparc.AI.Kernel
 {

--- a/src/Senparc.AI.Kernel/Helpers/SemanticKernelHelper.cs
+++ b/src/Senparc.AI.Kernel/Helpers/SemanticKernelHelper.cs
@@ -15,6 +15,7 @@ using Senparc.AI.Entities;
 using Senparc.AI.Entities.Keys;
 using Senparc.AI.Exceptions;
 using Senparc.AI.Interfaces;
+using Senparc.AI.Kernel.HttpMessageHandlers;
 using Senparc.CO2NET;
 
 // Memory functionality is experimental
@@ -61,7 +62,14 @@ namespace Senparc.AI.Kernel.Helpers
         /// <param name="httpClient"></param>
         public void ResetHttpClient(HttpClient httpClient = null, bool enableLog = false)
         {
-            _httpClient = httpClient ?? new HttpClient(new LoggingHttpMessageHandler(new HttpClientHandler(), enableLog));
+            var builder = new HttpMessageHandlerBuilder();
+
+            var handler = new HttpClientHandler();
+
+            builder.Add(new LoggingHttpMessageHandler(handler, enableLog));
+            builder.Add(new RedirectingHttpMessageHandler(handler, AiSetting.AiPlatform, AiSetting.OpenAIEndpoint));
+
+            _httpClient = httpClient ?? new HttpClient(builder.Build());
         }
 
         /// <summary>

--- a/src/Senparc.AI.Kernel/HttpMessageHandlers/HttpMessageHandlerBuilder.cs
+++ b/src/Senparc.AI.Kernel/HttpMessageHandlers/HttpMessageHandlerBuilder.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace Senparc.AI.Kernel.HttpMessageHandlers
+{
+    public class HttpMessageHandlerBuilder
+    {
+        private readonly List<HttpMessageHandler> _handlers;
+
+        public HttpMessageHandlerBuilder()
+        {
+            _handlers = new List<HttpMessageHandler>();
+        }
+
+        /// <summary>
+        /// 注册HttpMessageHandler，先注册的先调用
+        /// </summary>
+        /// <param name="handler"></param>
+        /// <returns></returns>
+        public HttpMessageHandlerBuilder Add(DelegatingHandler handler)
+        {
+            _handlers.Add(handler);
+            return this;
+        }
+
+        /// <summary>
+        /// 创建最终的HttpMessageHandler
+        /// </summary>
+        /// <returns></returns>
+        public DelegatingHandler Build()
+        {
+            DelegatingHandler wrapper = new ConcreteHttpMessageHandler();
+            DelegatingHandler current = wrapper;
+            HttpMessageHandler last = _handlers.Last();
+            
+            foreach (DelegatingHandler handler in _handlers)
+            {
+                if (handler == last)
+                {
+                    current.InnerHandler = handler;
+                }
+                else
+                {
+                    current.InnerHandler = handler;
+                    current = handler;
+                }
+            }
+            return wrapper;
+        }
+
+        public class ConcreteHttpMessageHandler : DelegatingHandler { }
+    }
+}

--- a/src/Senparc.AI.Kernel/HttpMessageHandlers/LoggingHttpMessageHandler.cs
+++ b/src/Senparc.AI.Kernel/HttpMessageHandlers/LoggingHttpMessageHandler.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Senparc.AI.Kernel
+namespace Senparc.AI.Kernel.HttpMessageHandlers
 {
     //public class CustomHttpMessageHandler : HttpClientHandler
     //{

--- a/src/Senparc.AI.Kernel/HttpMessageHandlers/RedirectingHttpMessageHandler.cs
+++ b/src/Senparc.AI.Kernel/HttpMessageHandlers/RedirectingHttpMessageHandler.cs
@@ -1,0 +1,31 @@
+﻿using Senparc.CO2NET.Extensions;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Senparc.AI.Kernel.HttpMessageHandlers
+{
+    public class RedirectingHttpMessageHandler: DelegatingHandler
+    {
+        private string? _endpoint;
+        private AiPlatform _aiPlatform;
+
+        public RedirectingHttpMessageHandler(HttpMessageHandler innerHandler, AiPlatform aiPlatform, string? endpoint) : base(innerHandler)
+        {
+            _endpoint = endpoint;
+            _aiPlatform = aiPlatform;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            //目前对OpenAI开放第三方代理API设置
+            if(_aiPlatform == AiPlatform.OpenAI && !_endpoint.IsNullOrEmpty())
+            {
+                request.RequestUri = new UriBuilder(request.RequestUri!) { Host = _endpoint }.Uri;
+            }
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/Senparc.AI/Entities/Keys/OpenAIKeys.cs
+++ b/src/Senparc.AI/Entities/Keys/OpenAIKeys.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
 using Senparc.AI.Entities.Keys;
 
 namespace Senparc.AI
@@ -9,5 +10,10 @@ namespace Senparc.AI
     {
         public string ApiKey { get; set; }
         public string OrganizationId { get; set; }
+
+        [JsonProperty(
+            NullValueHandling = NullValueHandling.Ignore, 
+            DefaultValueHandling =DefaultValueHandling.Ignore)]
+        public string? OpenAIEndpoint { get; set; }
     }
 }

--- a/src/Senparc.AI/Entities/SenparcAiSettingBase.cs
+++ b/src/Senparc.AI/Entities/SenparcAiSettingBase.cs
@@ -102,6 +102,15 @@ namespace Senparc.AI.Entities
                                                     ? OpenAIKeys?.OrganizationId
                                                     : FastAPIKeys?.OrganizationId;
 
+        #region OpenAI
+
+        /// <summary>
+        /// OpenAI Endpoint
+        /// </summary>
+        public virtual string OpenAIEndpoint => OpenAIKeys?.OpenAIEndpoint;
+
+        #endregion
+
         #region Azure OpenAI
 
         /// <summary>

--- a/src/Senparc.AI/Interfaces/ISenparcAiSetting.cs
+++ b/src/Senparc.AI/Interfaces/ISenparcAiSetting.cs
@@ -37,7 +37,7 @@ namespace Senparc.AI.Interfaces
 
         string Endpoint => AiPlatform switch
         {
-            AiPlatform.OpenAI => "无需配置",
+            AiPlatform.OpenAI => OpenAIEndpoint,
             AiPlatform.AzureOpenAI => AzureEndpoint,
             AiPlatform.NeuCharAI => NeuCharEndpoint,
             AiPlatform.HuggingFace => HuggingFaceEndpoint,
@@ -74,6 +74,15 @@ namespace Senparc.AI.Interfaces
         /// OpenAI API Orgaization ID
         /// </summary>
         string OrganizationId { get; }
+
+        #region OpenAI
+
+        /// <summary>
+        /// OpenAI Endpoint
+        /// </summary>
+        string OpenAIEndpoint { get; }
+
+        #endregion
 
         #region Azure OpenAI
 


### PR DESCRIPTION
在`appsettings.json`文件中的`"OpenAIKeys"`键下增加对`"OpenAIEndpoint"`键的支持，用来指定第三方代理OpenAI API地址。

以下情况会使用OpenAI官方API终结点：
- 该键未配置即不存在
- 该键的值为`null`或`""`

解决issue #19 