### PR TITLE
对接讯飞api。

### DIFF
--- a/Samples/Senaprc.AI.Samples.Agents/Senaprc.AI.Samples.Agents.csproj
+++ b/Samples/Senaprc.AI.Samples.Agents/Senaprc.AI.Samples.Agents.csproj
@@ -21,10 +21,6 @@
 
 	<ItemGroup>
 
-		<Content Include="appsettings.Development.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-
 		<Content Include="appsettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>

--- a/Samples/Senaprc.AI.Samples.Agents/appsettings.json
+++ b/Samples/Senaprc.AI.Samples.Agents/appsettings.json
@@ -17,12 +17,12 @@
   //Senparc.AI 设置
   "SenparcAiSetting": {
     "IsDebug": true,
-    "AiPlatform": "AzureOpenAI", //注意修改为自己平台对应的枚举值
+    "AiPlatform": "SparkAI", //注意修改为自己平台对应的枚举值
     "NeuCharAIKeys": {
-      "ApiKey": "<Your ApiKey>", //在 https://www.neuchar.com/Developer/AiApp 申请
-      "NeuCharEndpoint": "https://www.neuchar.com/<DeveloperId>", //查看 ApiKey 时可看到 DeveloperId
+      "ApiKey": "5b0b30df3fd44811bdbfed8fe07be3eb", //在 https://www.neuchar.com/Developer/AiApp 申请
+      "NeuCharEndpoint": "https://www.neuchar.com/18673", //查看 ApiKey 时可看到 DeveloperId
       "ModelName": {
-        "Chat": "gpt-35-turbo"
+        "Chat": "gpt-4-32k"
       }
     },
     "AzureOpenAIKeys": {
@@ -46,6 +46,15 @@
         "TextCompletion": "chatglm2"
       }
     },
+    "SparkAIKeys": {
+      "ApiKey": "40a519641152f3c7caecbcc416065ae1", //TODO：加密
+      "AppId": "a891b281",
+      "ApiSecret": "ODdhYjEzZTY3OGE4OWJkYTI0M2ZlNGIz",
+      "SparkAiEndpoint": "",
+      "ModelName": {
+        "Chat": "gpt-35-turbo"
+      }
+    },
     "Items": {
       "AzureDalle3": {
         "AiPlatform": "AzureOpenAI",
@@ -63,6 +72,18 @@
         "NeuCharAIKeys": {
           "ApiKey": "MyNeuCharAIKey",
           "NeuCharEndpoint": "https://www.neuchar.com/<DeveloperId>",
+          "ModelName": {
+            "Chat": "gpt-35-turbo"
+          }
+        }
+      },
+      "SparkAIKeys": {
+        "AiPlatform": "SparkAI",
+        "SparkAIKeys": {
+          "ApiKey": "40a519641152f3c7caecbcc416065ae1", //TODO：加密
+          "AppId": "a891b281",
+          "ApiSecret": "ODdhYjEzZTY3OGE4OWJkYTI0M2ZlNGIz",
+          "SparkAiEndpoint": "https://www.neuchar.com/<DeveloperId>/",
           "ModelName": {
             "Chat": "gpt-35-turbo"
           }

--- a/Samples/Senparc.AI.Samples.Consoles/Senparc.AI.Samples.Consoles.csproj
+++ b/Samples/Senparc.AI.Samples.Consoles/Senparc.AI.Samples.Consoles.csproj
@@ -10,19 +10,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <None Remove="appsettings.Development.json" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Content Include="appsettings.Development.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="appsettings.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />

--- a/Samples/Senparc.AI.Samples.Consoles/appsettings.json
+++ b/Samples/Senparc.AI.Samples.Consoles/appsettings.json
@@ -13,7 +13,7 @@
   //Senparc.AI 设置
   "SenparcAiSetting": {
     "IsDebug": true,
-    "AiPlatform": "NeuCharAI", //注意修改为自己平台对应的枚举值
+    "AiPlatform": "SparkAI", //注意修改为自己平台对应的枚举值
     "NeuCharAIKeys": {
       "ApiKey": "xxxxxxx", //在 https://www.neuchar.com/Developer/AiApp 申请
       "NeuCharEndpoint": "https://www.neuchar.com/<DeveloperId>", //查看 ApiKey 时可看到 DeveloperId，替换掉 <DeveloperId>
@@ -54,6 +54,15 @@
         "TextCompletion": "qwen:7b"
       }
     },
+    "SparkAIKeys": {
+      "ApiKey": "", //TODO：加密
+      "AppId": "",
+      "ApiSecret": "",
+      "SparkAiEndpoint": "",
+      "ModelName": {
+        "Chat": "gpt-35-turbo"
+      }
+    },
     "Items": {
       "AzureDalle3": {
         "AiPlatform": "AzureOpenAI",
@@ -76,6 +85,19 @@
           }
         }
       },
+      "SparkAIKeys": {
+        "AiPlatform": "SparkAI",
+        "SparkAIKeys": {
+          "ApiKey": "40a519641152f3c7caecbcc416065ae1", //TODO：加密
+          "AppId": "a891b281",
+          "ApiSecret": "ODdhYjEzZTY3OGE4OWJkYTI0M2ZlNGIz",
+          "SparkAiEndpoint": "https://www.neuchar.com/<DeveloperId>/",
+          "ModelName": {
+            "Chat": "gpt-35-turbo"
+          }
+        }
+      },
+
       "OtherModels": {
         "AiPlatform": "<AiPlatform>"
         //任意数量的 *Keys 配置

--- a/src/Senparc.AI.Kernel/Extensions.cs
+++ b/src/Senparc.AI.Kernel/Extensions.cs
@@ -85,7 +85,7 @@ namespace Senparc.AI.Kernel
 
 
         /// <summary>
-        /// 添加 SparkAI 聊天服务
+        /// 添加 SparkAI 聊天服务 现在只有简单聊天
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="modelId"></param>
@@ -94,14 +94,10 @@ namespace Senparc.AI.Kernel
         /// <param name="orgId"></param>
         /// <param name="serviceId"></param>
         /// <returns></returns>
-        public static IKernelBuilder AddSparkAIChatCompletion(this IKernelBuilder builder, string appId, string apiKey, string apiSecret)
-        {
-
-            string apiKey2 = apiKey;
-            string appId2 = appId;
-            string apiSecret2 = apiSecret;
+        public static IKernelBuilder AddSparkAIChatCompletion(this IKernelBuilder builder, string appId, string apiKey, string apiSecret,string modelVersion)
+        {         
             // Register SparkAIService as a singleton in the dependency injection container
-            builder.Services.AddSingleton<ITextGenerationService>(new SparkAIChatService(appId, apiKey, apiSecret));
+            builder.Services.AddSingleton<ITextGenerationService>(new SparkAIChatService(appId, apiKey, apiSecret,modelVersion));
             return builder;
         }
     }

--- a/src/Senparc.AI.Kernel/Extensions.cs
+++ b/src/Senparc.AI.Kernel/Extensions.cs
@@ -8,6 +8,9 @@ using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.TextGeneration;
 using Microsoft.SemanticKernel;
+using Sdcb.SparkDesk;
+using Senparc.AI.Kernel.SparkAI;
+using System.Net;
 
 namespace Senparc.AI.Kernel
 {
@@ -36,7 +39,21 @@ namespace Senparc.AI.Kernel
             builder.Services.AddKeyedSingleton((object?)serviceId, (Func<IServiceProvider, object?, ITextGenerationService>)implementationFactory);
             return builder;
         }
+        //public static IKernelBuilder AddFOllamaChatCompletion(this IKernelBuilder builder, string modelId, string endpoint, string serviceId = null)
+        //{
+        //    string modelId2 = modelId;
 
+
+        //    Func<IServiceProvider, object, OpenAIChatCompletionService> implementationFactory =
+        //        (IServiceProvider serviceProvider, object? _) =>
+        //        new OpenAIChatCompletionService(modelId, new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(apiKey)), serviceProvider.GetService<ILoggerFactory>());
+
+        //    OllamaApiClientExtensions.
+
+        //    builder.Services.AddKeyedSingleton((object?)serviceId, (Func<IServiceProvider, object?, IChatCompletionService>)implementationFactory);
+        //    builder.Services.AddKeyedSingleton((object?)serviceId, (Func<IServiceProvider, object?, ITextGenerationService>)implementationFactory);
+        //    return builder;
+        //}
         #region Ollama
 
         public static IKernelBuilder AddFOllamaChatCompletion(this IKernelBuilder builder, string modelId, string endpoint, string serviceId = null)
@@ -65,5 +82,27 @@ namespace Senparc.AI.Kernel
         }
 
         #endregion
+
+
+        /// <summary>
+        /// 添加 SparkAI 聊天服务
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="modelId"></param>
+        /// <param name="apiKey"></param>
+        /// <param name="endpoint"></param>
+        /// <param name="orgId"></param>
+        /// <param name="serviceId"></param>
+        /// <returns></returns>
+        public static IKernelBuilder AddSparkAIChatCompletion(this IKernelBuilder builder, string appId, string apiKey, string apiSecret)
+        {
+
+            string apiKey2 = apiKey;
+            string appId2 = appId;
+            string apiSecret2 = apiSecret;
+            // Register SparkAIService as a singleton in the dependency injection container
+            builder.Services.AddSingleton<ITextGenerationService>(new SparkAIChatService(appId, apiKey, apiSecret));
+            return builder;
+        }
     }
 }

--- a/src/Senparc.AI.Kernel/Helpers/SemanticKernelHelper.Config.cs
+++ b/src/Senparc.AI.Kernel/Helpers/SemanticKernelHelper.Config.cs
@@ -96,7 +96,9 @@ namespace Senparc.AI.Kernel.Helpers
 					     AiPlatform.SparkAI => kernelBuilder.AddSparkAIChatCompletion(
                    apiKey: senparcAiSetting.ApiKey,
                    appId: senparcAiSetting.SparkAIKeys.AppId,
-                   apiSecret: senparcAiSetting.SparkAIKeys.ApiSecret
+                   apiSecret: senparcAiSetting.SparkAIKeys.ApiSecret,
+                  modelVersion: senparcAiSetting.SparkAIKeys.ModelVersion
+                   
                ),
                 _ => throw new SenparcAiException($"没有处理当前 {nameof(AiPlatform)} 类型：{aiPlatForm}")
             };
@@ -171,7 +173,8 @@ namespace Senparc.AI.Kernel.Helpers
 					AiPlatform.SparkAI => kernelBuilder.AddSparkAIChatCompletion(
                       appId:senparcAiSetting.SparkAIKeys.AppId,
                       apiKey:senparcAiSetting.SparkAIKeys.ApiKey,
-                      apiSecret:senparcAiSetting.SparkAIKeys.ApiSecret
+                      apiSecret:senparcAiSetting.SparkAIKeys.ApiSecret,
+                      modelVersion:senparcAiSetting.SparkAIKeys.ModelVersion
                     ),
                 //AiPlatform.Ollama => kernelBuilder.AddOpenAIChatCompletion(
                 //        modelId: modelName,

--- a/src/Senparc.AI.Kernel/Helpers/SemanticKernelHelper.Config.cs
+++ b/src/Senparc.AI.Kernel/Helpers/SemanticKernelHelper.Config.cs
@@ -93,6 +93,11 @@ namespace Senparc.AI.Kernel.Helpers
                         endpoint: senparcAiSetting.OllamaEndpoint,
                         serviceId: null
                     ),
+					     AiPlatform.SparkAI => kernelBuilder.AddSparkAIChatCompletion(
+                   apiKey: senparcAiSetting.ApiKey,
+                   appId: senparcAiSetting.SparkAIKeys.AppId,
+                   apiSecret: senparcAiSetting.SparkAIKeys.ApiSecret
+               ),
                 _ => throw new SenparcAiException($"没有处理当前 {nameof(AiPlatform)} 类型：{aiPlatForm}")
             };
 
@@ -163,6 +168,18 @@ namespace Senparc.AI.Kernel.Helpers
                         endpoint: senparcAiSetting.OllamaEndpoint,
                         serviceId: null
                     ),
+					AiPlatform.SparkAI => kernelBuilder.AddSparkAIChatCompletion(
+                      appId:senparcAiSetting.SparkAIKeys.AppId,
+                      apiKey:senparcAiSetting.SparkAIKeys.ApiKey,
+                      apiSecret:senparcAiSetting.SparkAIKeys.ApiSecret
+                    ),
+                //AiPlatform.Ollama => kernelBuilder.AddOpenAIChatCompletion(
+                //        modelId: modelName,
+                //        apiKey: senparcAiSetting.ApiKey,
+                //        orgId: senparcAiSetting.OrganizationId,
+                //        endpoint: senparcAiSetting.FastAPIEndpoint,
+                //        serviceId: null
+                //    ),
                 _ => throw new SenparcAiException($"没有处理当前 {nameof(AiPlatform)} 类型：{aiPlatForm}")
             };
 

--- a/src/Senparc.AI.Kernel/Senparc.AI.Kernel.csproj
+++ b/src/Senparc.AI.Kernel/Senparc.AI.Kernel.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 		<PropertyGroup>
 				<TargetFramework>netstandard2.1</TargetFramework>
-				<Version>0.19.0</Version>
+				<Version>0.19.3</Version>
 				<Nullable>enable</Nullable>
 				<LangVersion>10.0</LangVersion>
 				<AssemblyName>Senparc.AI.Kernel</AssemblyName>
@@ -73,11 +73,18 @@
 				<!--<PackageReference Include="Microsoft.SemanticKernel.Functions.Semantic" Version="1.0.0-beta2" />-->
 				<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.16.2-alpha" />
 				<PackageReference Include="Sdcb.SparkDesk" Version="3.1.0" />
-				<!--<PackageReference Include="Ollama" Version="1.6.1" />-->
-				<!--<PackageReference Include="OllamaSharp" Version="2.0.13" />-->
-				<PackageReference Include="Senparc.CO2NET" Version="2.4.3" />
-		</ItemGroup>
-		<ItemGroup>
-				<ProjectReference Include="..\Senparc.AI\Senparc.AI.csproj" />
-		</ItemGroup>
+
+      <!--<PackageReference Include="Ollama" Version="1.6.1" />-->
+      <!--<PackageReference Include="OllamaSharp" Version="2.0.13" />-->
+      <PackageReference Include="Senparc.CO2NET" Version="2.4.3" />
+    </ItemGroup>
+ <ItemGroup Condition="'$(Configuration)' == 'Release'">
+      <PackageReference Include="Senparc.AI" Version="0.16.7" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' != 'Release'">
+    <ProjectReference Include="..\Senparc.AI\Senparc.AI.csproj" />
+  </ItemGroup>  
+  
+    
+ 
 </Project>

--- a/src/Senparc.AI.Kernel/Senparc.AI.Kernel.csproj
+++ b/src/Senparc.AI.Kernel/Senparc.AI.Kernel.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 		<PropertyGroup>
 				<TargetFramework>netstandard2.1</TargetFramework>
-				<Version>0.18.0</Version>
+				<Version>0.19.0</Version>
 				<Nullable>enable</Nullable>
 				<LangVersion>10.0</LangVersion>
 				<AssemblyName>Senparc.AI.Kernel</AssemblyName>
@@ -67,10 +67,12 @@
 				<None Include="KernelConfigExtensions\KernelConfigExtensions.Function.cs" />
 		</ItemGroup>
 		<ItemGroup>
+				<PackageReference Include="Humanizer.Core" Version="2.14.1" />
 				<PackageReference Include="Microsoft.SemanticKernel" Version="1.16.2" />
 				<PackageReference Include="Microsoft.SemanticKernel.Connectors.HuggingFace" Version="1.16.2-preview" />
 				<!--<PackageReference Include="Microsoft.SemanticKernel.Functions.Semantic" Version="1.0.0-beta2" />-->
 				<PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.16.2-alpha" />
+				<PackageReference Include="Sdcb.SparkDesk" Version="3.1.0" />
 				<!--<PackageReference Include="Ollama" Version="1.6.1" />-->
 				<!--<PackageReference Include="OllamaSharp" Version="2.0.13" />-->
 				<PackageReference Include="Senparc.CO2NET" Version="2.4.3" />

--- a/src/Senparc.AI.Kernel/SparkAI/SparkAIChatService.cs
+++ b/src/Senparc.AI.Kernel/SparkAI/SparkAIChatService.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.TextGeneration;
+using Sdcb.SparkDesk;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using static Humanizer.On;
+
+
+namespace Senparc.AI.Kernel.SparkAI
+{
+    /// <summary>
+    /// 讯飞星火api
+    /// </summary>
+    public class SparkAIChatService : ITextGenerationService
+    {
+        private readonly SparkDeskClient _client;
+        private readonly string _appId;
+        private readonly string _apiKey;
+        private readonly string _apiSecret;
+
+        public SparkAIChatService(string appId, string apiKey, string apiSecret)
+        {
+            _appId = appId;
+            _apiKey = apiKey;
+            _apiSecret = apiSecret;
+            _client = new SparkDeskClient(appId, apiKey, apiSecret);
+        }
+
+        public IReadOnlyDictionary<string, object?> Attributes => throw new NotImplementedException();
+
+        public async Task<string> ChatAsync(string[] userMessages)
+        {
+            StringBuilder sb = new StringBuilder();
+            List<ChatMessage> messages = new List<ChatMessage>();
+
+            foreach (var message in userMessages)
+            {
+                messages.Add(ChatMessage.FromUser(message));
+            }
+
+            // 假设这里的 ModelVersion.V2_0 是一个有效的版本指示。
+            TokensUsage usage = await _client.ChatAsStreamAsync(ModelVersion.Max, messages.ToArray(), s => sb.Append(s), uid: "zhoujie");
+
+            return sb.ToString();
+        }
+
+        public async IAsyncEnumerable<StreamingTextContent> GetStreamingTextContentsAsync(string prompt, PromptExecutionSettings? executionSettings = null, Microsoft.SemanticKernel.Kernel? kernel = null, CancellationToken cancellationToken = default)
+        {
+
+
+            // 构建消息数组，这里使用 prompt 来构建 ChatMessage
+            var messages = new List<ChatMessage>
+    {
+        ChatMessage.FromUser(prompt)
+    };
+
+            // 用于接收来自 API 的文本数据的 StringBuilder
+            StringBuilder sb = new StringBuilder();
+
+            // 调用 ChatAsStreamAsync 方法，该方法异步接收聊天消息
+            //TokensUsage usage = await _client.ChatAsStreamAsync(ModelVersion.V3, messages.ToArray(), s => sb.Append(s), uid: "zhoujie", cancellationToken: cancellationToken);
+
+            //// 解析流式数据并生成 StreamingTextContent 实例
+            //// 假设每次调用返回全部文本，我们可以直接生成一个 StreamingTextContent 对象
+            //yield return new StreamingTextContent(sb.ToString(), encoding: Encoding.UTF8);
+            // Ensure ChatAsStreamAsync is an async streaming method
+            await foreach (var response in _client.ChatAsStreamAsync(ModelVersion.Max, messages.ToArray()))
+            {
+                yield return new StreamingTextContent(response.Text, encoding: Encoding.UTF8);
+            }
+        }
+
+        public async Task<IReadOnlyList<TextContent>> GetTextContentsAsync(string prompt, PromptExecutionSettings? executionSettings = null, Microsoft.SemanticKernel.Kernel? kernel = null, CancellationToken cancellationToken = default)
+        {
+
+
+            // 调用 ChatAsync 方法并获取响应
+            ChatResponse response = await _client.ChatAsync(ModelVersion.Max, new ChatMessage[]
+            {
+        ChatMessage.FromUser(prompt)
+            });
+
+            // 创建并返回 TextContent 列表
+            return new List<TextContent>
+    {
+        new TextContent {  Text=response.Text }
+    };
+        }
+
+
+    }
+
+}

--- a/src/Senparc.AI.Kernel/SparkAI/SparkAIChatService.cs
+++ b/src/Senparc.AI.Kernel/SparkAI/SparkAIChatService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.TextGeneration;
 using Sdcb.SparkDesk;
+using Senparc.AI.Entities.Keys;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -20,12 +21,31 @@ namespace Senparc.AI.Kernel.SparkAI
         private readonly string _appId;
         private readonly string _apiKey;
         private readonly string _apiSecret;
-
-        public SparkAIChatService(string appId, string apiKey, string apiSecret)
+        private readonly ModelVersion _modelVersion;
+        public SparkAIChatService(string appId, string apiKey, string apiSecret,string modelVersion= "4_0_ultra")
         {
+
             _appId = appId;
             _apiKey = apiKey;
             _apiSecret = apiSecret;
+            
+            switch (modelVersion?.ToLower()) {
+                case "lite":
+                    _modelVersion = ModelVersion.Lite;
+                    break;
+                case "pro":
+                    _modelVersion = ModelVersion.Pro;break;
+                case "max":
+                    _modelVersion = ModelVersion.Max;
+                    break;
+                case "4_0_ultra":
+                    _modelVersion = ModelVersion.V4_0_Ultra;
+                    break;
+                default:
+                    _modelVersion = ModelVersion.V4_0_Ultra; break;
+            
+            
+            }
             _client = new SparkDeskClient(appId, apiKey, apiSecret);
         }
 
@@ -42,7 +62,7 @@ namespace Senparc.AI.Kernel.SparkAI
             }
 
             // 假设这里的 ModelVersion.V2_0 是一个有效的版本指示。
-            TokensUsage usage = await _client.ChatAsStreamAsync(ModelVersion.Max, messages.ToArray(), s => sb.Append(s), uid: "zhoujie");
+            TokensUsage usage = await _client.ChatAsStreamAsync(_modelVersion, messages.ToArray(), s => sb.Append(s), uid: "zhoujie");
 
             return sb.ToString();
         }
@@ -67,7 +87,7 @@ namespace Senparc.AI.Kernel.SparkAI
             //// 假设每次调用返回全部文本，我们可以直接生成一个 StreamingTextContent 对象
             //yield return new StreamingTextContent(sb.ToString(), encoding: Encoding.UTF8);
             // Ensure ChatAsStreamAsync is an async streaming method
-            await foreach (var response in _client.ChatAsStreamAsync(ModelVersion.Max, messages.ToArray()))
+            await foreach (var response in _client.ChatAsStreamAsync(_modelVersion, messages.ToArray()))
             {
                 yield return new StreamingTextContent(response.Text, encoding: Encoding.UTF8);
             }
@@ -78,7 +98,7 @@ namespace Senparc.AI.Kernel.SparkAI
 
 
             // 调用 ChatAsync 方法并获取响应
-            ChatResponse response = await _client.ChatAsync(ModelVersion.Max, new ChatMessage[]
+            ChatResponse response = await _client.ChatAsync(_modelVersion, new ChatMessage[]
             {
         ChatMessage.FromUser(prompt)
             });

--- a/src/Senparc.AI/Entities/Keys/SparkAIKeys.cs
+++ b/src/Senparc.AI/Entities/Keys/SparkAIKeys.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Senparc.AI.Entities.Keys;
+
+namespace Senparc.AI
+{
+    /// <summary>
+    /// 科大讯飞
+    /// </summary>
+    public class SparkAIKeys : BaseKeys
+    {
+        //public string ApiKey { get; set; }
+        //public string OrganizationId { get; set; }
+
+        // 应用APPID（必须为webapi类型应用，并开通星火认知大模型授权）
+        public string AppId { get; set; }
+
+        // 接口密钥（webapi类型应用开通星火认知大模型后，控制台--我的应用---星火认知大模型---相应服务的apikey）
+        public string ApiSecret { get; set; }
+        // 接口密钥（webapi类型应用开通星火认知大模型后，控制台--我的应用---星火认知大模型---相应服务的apisecret）
+        public string ApiKey { get; set; }
+
+        public string SparkAIEndpoint { get; set; }
+
+
+
+
+    }
+}

--- a/src/Senparc.AI/Entities/Keys/SparkAIKeys.cs
+++ b/src/Senparc.AI/Entities/Keys/SparkAIKeys.cs
@@ -22,8 +22,10 @@ namespace Senparc.AI
         public string ApiKey { get; set; }
 
         public string SparkAIEndpoint { get; set; }
-
-
+        /// <summary>
+        /// 版本 
+        /// </summary>
+        public string ModelVersion { get; set; }
 
 
     }

--- a/src/Senparc.AI/Entities/SenparcAiSettingBase.cs
+++ b/src/Senparc.AI/Entities/SenparcAiSettingBase.cs
@@ -71,6 +71,7 @@ namespace Senparc.AI.Entities
         /// 是否使用 Ollama
         /// </summary>
         public virtual bool Ollama => AiPlatform == AiPlatform.Ollama;
+		public virtual bool UseSparkAI => AiPlatform == AiPlatform.SparkAI;
 
         /// <summary>
         /// AI 平台类型
@@ -87,6 +88,10 @@ namespace Senparc.AI.Entities
         public virtual FastAPIKeys FastAPIKeys { get; set; }
         public virtual OllamaKeys OllamaKeys { get; set; }
 
+    /// <summary>
+        /// 科大讯飞api
+        /// </summary>
+        public virtual SparkAIKeys SparkAIKeys { get; set; }
         /// <summary>
         /// Azure OpenAI 或 OpenAI API Key
         /// </summary>
@@ -98,6 +103,7 @@ namespace Senparc.AI.Entities
             AiPlatform.HuggingFace => "",
             AiPlatform.FastAPI => FastAPIKeys.ApiKey,
             AiPlatform.Ollama => "",
+			AiPlatform.SparkAI => SparkAIKeys.ApiKey,
             _ => ""
         };
 
@@ -164,6 +170,12 @@ namespace Senparc.AI.Entities
 
         #region Ollama
         public string OllamaEndpoint => OllamaKeys?.Endpoint;
+
+        #endregion
+
+        #region SparkAI
+
+        public virtual string SparkAIEndpoint => SparkAIKeys?.SparkAIEndpoint; 
 
         #endregion
 
@@ -253,5 +265,19 @@ namespace Senparc.AI.Entities
         }
 
         #endregion
+
+        /// <summary>
+        /// 设置 SparkAI
+        /// </summary>
+        /// <param name="neuCharAIKeys"></param>
+        /// <returns></returns>
+        public ISenparcAiSetting SetSparkAI(SparkAIKeys sparkAIKeys)
+        {
+            this.AiPlatform = AiPlatform.SparkAI;
+            this.SparkAIKeys = sparkAIKeys;
+            return this;
+        }
+
+
     }
 }

--- a/src/Senparc.AI/Enums.cs
+++ b/src/Senparc.AI/Enums.cs
@@ -21,6 +21,7 @@ namespace Senparc.AI
         //Oobabooga = 64,//未实现
         FastAPI = 128,
         Ollama = 256,
+		 SparkAI=512
     }
 
     /// <summary>

--- a/src/Senparc.AI/Interfaces/ISenparcAiSetting.cs
+++ b/src/Senparc.AI/Interfaces/ISenparcAiSetting.cs
@@ -43,6 +43,7 @@ namespace Senparc.AI.Interfaces
             AiPlatform.HuggingFace => HuggingFaceEndpoint,
             AiPlatform.FastAPI => FastAPIEndpoint,
             AiPlatform.Ollama => OllamaEndpoint,
+			AiPlatform.SparkAI=>SparkAIEndpoint,
             _ => throw new SenparcAiException($"未配置 {AiPlatform} 的 Endpoint 输出")
         };
 
@@ -55,6 +56,7 @@ namespace Senparc.AI.Interfaces
         /// 是否使用 NeuChar OpenAI
         /// </summary>
         bool UseNeuCharAI => AiPlatform == AiPlatform.NeuCharAI;
+ bool UseSparkAI => AiPlatform == AiPlatform.SparkAI;
         /// <summary>
         /// AI 平台类型
         /// </summary>
@@ -66,6 +68,8 @@ namespace Senparc.AI.Interfaces
         HuggingFaceKeys HuggingFaceKeys { get; set; }
         FastAPIKeys FastAPIKeys { get; set; }
         OllamaKeys  OllamaKeys { get; set; }
+		
+        SparkAIKeys SparkAIKeys { get; set; }
 
         /// <summary>
         /// Neuchar OpenAI 或 Azure OpenAI 或 OpenAI API Key
@@ -79,10 +83,7 @@ namespace Senparc.AI.Interfaces
 
         #region OpenAI
 
-        /// <summary>
-        /// OpenAI Endpoint
-        /// </summary>
-        string OpenAIEndpoint { get; }
+    
 
         #endregion
 
@@ -124,6 +125,14 @@ namespace Senparc.AI.Interfaces
 
         #endregion
 
+        #region OpenAI
+
+        /// <summary>
+        /// OpenAI Endpoint
+        /// </summary>
+        string OpenAIEndpoint { get; }
+
+        #endregion
         #region FastAPI
 
         string FastAPIEndpoint { get; }
@@ -135,7 +144,9 @@ namespace Senparc.AI.Interfaces
         string OllamaEndpoint { get; }
 
         #endregion
-
+ 		 #region SparkAI
+        string SparkAIEndpoint { get; }
+        #endregion
         /// <summary>
         /// OpenAIKeys 是否已经设置
         /// </summary>
@@ -150,6 +161,7 @@ namespace Senparc.AI.Interfaces
             AiPlatform.HuggingFace => HuggingFaceKeys.ModelName,
             AiPlatform.FastAPI => FastAPIKeys.ModelName,
             AiPlatform.Ollama => OllamaKeys.ModelName,
+			 AiPlatform.SparkAI=>SparkAIKeys.ModelName,
             _ => throw new SenparcAiException($"100-未配置 {AiPlatform} 的 Endpoint 输出")
         };
 
@@ -162,6 +174,7 @@ namespace Senparc.AI.Interfaces
             AiPlatform.HuggingFace => null,
             AiPlatform.FastAPI => null,
             AiPlatform.Ollama => null,
+			AiPlatform.SparkAI=>null,
             _ => throw new SenparcAiException($"未配置 {AiPlatform} 的 DeploymentName 输出")
         };
 #pragma warning restore CS8603 // 可能返回 null 引用。

--- a/src/Senparc.AI/Senparc.AI.csproj
+++ b/src/Senparc.AI/Senparc.AI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.16.5</Version>
+    <Version>0.16.7</Version>
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
     <AssemblyName>Senparc.AI</AssemblyName>


### PR DESCRIPTION
因为第一次提交，采用github的对接讯飞ai的 库。
集成到senparc.ai 
已经测试过 ，在ncf项目中使用。
靶场还有公众号管理的ai回复。

请苏老师指点下，接下去要如何完善， 现在只有单纯的聊天。
也想着是不是重新写基础的讯飞api